### PR TITLE
[PKG-2781] 1.3.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.17.8" %}
+{% set version = "1.3.8" %}
 
 package:
   name: great-expectations
@@ -6,53 +6,46 @@ package:
 
 source:
   url: https://pypi.io/packages/source/g/great-expectations/great_expectations-{{ version }}.tar.gz
-  sha256: a13bb1827f3c710d059db18cea727961b8fb90d1f7656d03e1c9c5bcf7bb52bf
+  sha256: 60da354d5cb0be07291f985966ff66800af9dee0d2c16e8af6efb9d1a9b39adf
 
 build:
-  noarch: python
+  skip: True  # [py<39]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - great_expectations = great_expectations.cli:main
 
 requirements:
   host:
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
     - pip
   run:
-    - pydantic >=1.9.2,<2.0
-    - marshmallow >=3.7.1,<4.0.0
-    - makefun >=1.7.0,<2
-    - notebook >=6.4.10
-    - dataclasses
-    - ipython >=7.16.3
-    - colorama >=0.4.3
-    - cryptography >=3.2
-    - nbformat >=5.0
-    - packaging
-    - typing-extensions >=3.10.0.0
-    - urllib3 >=1.26
-    - python >=3.6
     - altair >=4.2.1,<5.0.0
-    - click >=7.1.2,<=8.1.3
-    - importlib-metadata >=1.7.0
-    - ipywidgets >=7.5.1
-    - jinja2 >=2.10
-    - jsonpatch >=1.22
+    - cryptography >=3.2
+    - jinja2 >=3
     - jsonschema >=2.5.1
+    - marshmallow >=3.7.1,<4.0.0
     - mistune >=0.8.4
-    - numpy >=1.19.5
-    - pandas >=1.1.0,<2
+    - numpy >=1.21.6  # [py==39]
+    - numpy >=1.22.4  # [py>=310 and py<312]
+    - numpy >=1.26.0  # [py>=312]
+    - packaging
+    - pandas >=1.1.3,<2.2  # [py==39]
+    - pandas >=1.3.0,<2.2  # [py>=310 and py<312]
+    - pandas <2.2  # [py>=312]
+    - posthog >3,<4
+    - pydantic >=1.10.7
     - pyparsing >=2.4
     - python-dateutil >=2.8.1
-    - pytz >=2021.3
     - requests >=2.20
-    - ruamel.yaml >=0.16,<0.17.18
+    - ruamel.yaml >=0.16
     - scipy >=1.6.0
-    - termcolor >=1.1.0,<2.1.0
     - tqdm >=4.59.0
+    - typing-extensions >=4.1.0
     - tzlocal >=1.2
-    - typing_extensions >=3.10.0.0
+    - python
   run_constrained:
     - sqlalchemy >=1.3.16
     - pyspark >=2.3.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,6 @@ build:
   skip: True  # [py<39]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  entry_points:
-    - great_expectations = great_expectations.cli:main
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.8" %}
+{% set version = "1.3.10" %}
 
 package:
   name: great-expectations
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/g/great-expectations/great_expectations-{{ version }}.tar.gz
-  sha256: 60da354d5cb0be07291f985966ff66800af9dee0d2c16e8af6efb9d1a9b39adf
+  sha256: 250e6dae9dc1496ea995ae308f903f0736fd57cb41decec2041425b8939e2840
 
 build:
   skip: True  # [py<39]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
-
 requirements:
   host:
     - python
@@ -105,7 +104,6 @@ test:
     - pip
   commands:
     - pip check
-    - great_expectations --help
 
 about:
   home: https://github.com/great-expectations/great_expectations

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,55 @@ requirements:
   run_constrained:
     - sqlalchemy >=1.3.16
     - pyspark >=2.3.2
+    # Extra: arrow
+    - feather-format >=0.4.1
+    # Extra: athena
+    - pyathena <3,>=2.0.0
+    - sqlalchemy >=1.4.0,<2.0.0
+    # Extra: s3
+    - boto3 >=1.17.106
+    # Extra: azure_secrets
+    - azure-identity >=1.10.0
+    - azure-keyvault-secrets >=4.0.0
+    - azure-storage-blob >=12.5.0
+    # Extra: gcp
+    - gcsfs >=0.5.1
+    - google-cloud-bigquery-core >=3.3.6
+    - google-cloud-bigquery-storage >=2.20.0
+    - google-cloud-secret-manager >=1.0.0
+    - google-cloud-storage >=2.10.0  # [py>=311]
+    - google-cloud-storage >=1.28.0  # [py<311]
+    - sqlalchemy-bigquery >=1.3.0
+    # Extra: clickhouse
+    - clickhouse-sqlalchemy >=0.2.2  # [py<312]
+    - clickhouse-sqlalchemy >=0.3.0  # [py>=312]
+    # Extra: cloud
+    - orjson >=3.9.7
+    # Extra: databricks
+    - databricks-sqlalchemy >=1.0.0
+    # Extra: mssql
+    - pyodbc >=4.0.30
+    # Extra: dremio
+    - sqlalchemy-dremio ==1.2.1
+    # Extra: excel
+    - openpyxl >=3.0.7
+    - xlrd >=1.1.0,<2.0.0
+    # Extra: hive
+    - PyHive >=0.6.5
+    - thrift >=0.16.0
+    - thrift-sasl >=0.4.3
+    # Extra: mysql
+    - PyMySQL >=1.1.1
+    # Extra: pagerduty
+    - pypd ==1.1.0
+    # Extra: postgresql
+    - psycopg2-binary >=2.7.6
+    # Extra: redshift
+    - sqlalchemy-redshift >=0.8.8
+    # Extra: snowflake
+    - snowflake-connector-python >=2.5.0 # [py<311]
+    - snowflake-connector-python >2.9.0  # [py>=311]
+    - snowflake-sqlalchemy >=1.2.3,!=1.7.0
 
 test:
   imports:


### PR DESCRIPTION
great-expectations 1.3.8

**Destination channel:** defaults

### Links

- [PKG-2781]
- [Upstream repository](https://github.com/great-expectations/great_expectations)
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/altair-feedstock/pull/5
  - https://github.com/AnacondaRecipes/posthog-feedstock/pull/3
  - https://github.com/AnacondaRecipes/makefun-feedstock/pull/3 (Unused in final recipe)

### Explanation of changes:

- Updated version and requirements
- Upstream tests skipped as there are several missing dependencies.
- CLI has been removed upstream, so I dropped the related test and entry point.

[PKG-2781]: https://anaconda.atlassian.net/browse/PKG-2781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ